### PR TITLE
Path al TA configurable

### DIFF
--- a/lib/afipws/wsaa.rb
+++ b/lib/afipws/wsaa.rb
@@ -16,7 +16,7 @@ module Afipws
       @ttl = options[:ttl] || 2400
       @cuit = options[:cuit]
       @client = Client.new Hash(options[:savon]).reverse_merge(wsdl: WSDL[@env])
-      @ta_path = File.join(Dir.pwd, 'tmp', "#{@cuit}-#{@env}-#{@service}-ta.dump")
+      @ta_path = options[:ta_path] || File.join(Dir.pwd, 'tmp', "#{@cuit}-#{@env}-#{@service}-ta.dump")
     end
 
     def generar_tra service, ttl


### PR DESCRIPTION
Esto es útil si no se quiere utilizar el directorio `tmp` y/o si se utiliza un mismo certificado para distintos CUITs.

Ejemplo: `Afipws::WSFE.new(cuit: '...', env: '...', key: '...', cert: '...', ta_path: 'temp/ta-wsfe.dump')`