### PR TITLE
Check if TA is not empty before loading

### DIFF
--- a/lib/afipws/wsaa.rb
+++ b/lib/afipws/wsaa.rb
@@ -89,7 +89,7 @@ module Afipws
     end
 
     def restore_ta
-      Marshal.load(File.read(@ta_path)) if File.exist?(@ta_path)
+      Marshal.load(File.read(@ta_path)) if File.exist?(@ta_path) && !File.zero?(@ta_path)
     end
 
     def persist_ta ta


### PR DESCRIPTION
Este cambio es sencillo y sirve para el caso en el cual se quiere utilizar un `Tempfile` para guardar temporalmente el TA. Dado que los `tempfiles` tienen nombres únicos, es imposible saberlo previamente y, por ende, siempre van a estar creados cuando se quiera hacer el `#load`.