### PR TITLE
Update ssl_version to TLS v1.2

### DIFF
--- a/lib/afipws/client.rb
+++ b/lib/afipws/client.rb
@@ -1,7 +1,7 @@
 module Afipws
   class Client
     def initialize savon_options
-      @client = Savon.client savon_options.reverse_merge(soap_version: 2, ssl_version: :TLSv1)
+      @client = Savon.client savon_options.reverse_merge(soap_version: 2, ssl_version: :TLSv1_2)
     end
 
     def request action, body = nil


### PR DESCRIPTION
Las versiones de TLS (v 1.0 y 1.1) serán discontinuadas debido a que resultan versiones obsoletas y sujetas a riesgos de seguridad. Se ruega a los usuarios realizar las adecuaciones necesarias de sus servicios webs y aplicativos al protocolo TLS v1.2, dado que los mismos podrían verse afectados con motivo de estas actualizaciones.

Link con más info: https://www.afip.gob.ar/ws/