### PR TITLE
feat: se agrega el método retriable? a Error

### DIFF
--- a/lib/afipws/client.rb
+++ b/lib/afipws/client.rb
@@ -8,6 +8,8 @@ module Afipws
       @savon.call action, message: body
     rescue Savon::SOAPFault => e
       raise ServerError, e
+    rescue HTTPClient::ConnectTimeoutError => e
+      raise NetworkError.new(e, retriable: true)
     rescue HTTPClient::TimeoutError => e
       raise NetworkError, e
     end

--- a/lib/afipws/errors/error.rb
+++ b/lib/afipws/errors/error.rb
@@ -3,5 +3,9 @@ module Afipws
     def code? _code
       false
     end
+
+    def retriable?
+      false
+    end
   end
 end

--- a/lib/afipws/errors/network_error.rb
+++ b/lib/afipws/errors/network_error.rb
@@ -1,4 +1,13 @@
 module Afipws
   class NetworkError < Error
+    def initialize e, retriable: false
+      super e
+
+      @retriable = retriable
+    end
+
+    def retriable?
+      @retriable
+    end
   end
 end


### PR DESCRIPTION
Esto permite al que consuma los errores decidir si quiere reintentarlos o no. En primera instancia el único marcado como reintentable es el que resulta de encapsular HTTPClient::ConnectTimeoutError, pero se pueden seguir agregando sin romper la API.

Closes #36 